### PR TITLE
Address 0.3.0 release review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,9 +38,9 @@
   to keep push-to-talk latency predictable.
 - Extended the model-load wait boundary so integrity checks cannot falsely time
   out during normal disk contention.
-- Made virtual typing acknowledged and lossless, and corrected divergent partial
-  text from the final transcript, including clearing stale streamed text when
-  the final transcript is empty.
+- Made virtual typing acknowledged before transcript state advances, and
+  corrected divergent partial text from the final transcript, including
+  clearing stale streamed text when the final transcript is empty.
 - Surfaced dictation and speech-model failures in the UI instead of logging
   them silently, including failures on the global-shortcut path.
 - Added a production Content Security Policy.

--- a/README.md
+++ b/README.md
@@ -134,6 +134,13 @@ macOS builds are not yet notarized, so the first updater-enabled release must be
 installed manually; once installed, the app checks for newer signed releases and
 installs them automatically.
 
+On first launch, try to open SilentKeys once, then open **System Settings →
+Privacy & Security**, scroll to **Security**, and click **Open Anyway**. Confirm
+the warning with **Open**. Only bypass Gatekeeper for a download you obtained
+from the SilentKeys releases page. See
+[Apple's guidance](https://support.apple.com/guide/mac-help/open-a-mac-app-from-an-unknown-developer-mh40616/mac)
+for the current macOS steps and security warning.
+
 ### Build from Source
 Install the [prerequisites](#prerequisites) listed under Quick Start, then run:
 ```bash

--- a/src-tauri/src/asr/model_store/paths.rs
+++ b/src-tauri/src/asr/model_store/paths.rs
@@ -112,8 +112,13 @@ where
 {
     let root = root.as_ref();
     let snapshot = root.join("snapshots").join(MODEL_SPEC.revision);
-    if verification::receipt_matches(&snapshot, MODEL_SPEC.revision, MODEL_SPEC.assets) {
-        return Ok(snapshot);
+    match verification::receipt_matches(&snapshot, MODEL_SPEC.revision, MODEL_SPEC.assets) {
+        Ok(true) => return Ok(snapshot),
+        Ok(false) => {}
+        Err(error) => log::warn!(
+            "Could not inspect model verification receipt at {}: {error}",
+            snapshot.display()
+        ),
     }
 
     let invalid = invalid_model_files(&snapshot)?;

--- a/src-tauri/src/asr/model_store/verification.rs
+++ b/src-tauri/src/asr/model_store/verification.rs
@@ -1,7 +1,7 @@
 use std::fs::{self, OpenOptions};
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
-use std::time::UNIX_EPOCH;
+use std::time::{SystemTimeError, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
 
@@ -9,6 +9,52 @@ use super::ModelAsset;
 
 const RECEIPT_FILE: &str = ".silentkeys-verified.json";
 const RECEIPT_SCHEMA_VERSION: u32 = 1;
+
+#[derive(thiserror::Error, Debug)]
+pub(super) enum VerificationError {
+    #[error("{operation} {}: {source}", path.display())]
+    Io {
+        operation: &'static str,
+        path: PathBuf,
+        #[source]
+        source: io::Error,
+    },
+    #[error("serialize model verification receipt {}: {source}", path.display())]
+    Serialize {
+        path: PathBuf,
+        #[source]
+        source: serde_json::Error,
+    },
+    #[error(
+        "model asset metadata does not match {} (expected a {expected_size}-byte file)",
+        path.display()
+    )]
+    AssetMetadata { path: PathBuf, expected_size: u64 },
+    #[error("read model asset modification time {}: {source}", path.display())]
+    ModifiedTime {
+        path: PathBuf,
+        #[source]
+        source: SystemTimeError,
+    },
+}
+
+impl VerificationError {
+    fn io(operation: &'static str, path: &Path, source: io::Error) -> Self {
+        Self::Io {
+            operation,
+            path: path.to_path_buf(),
+            source,
+        }
+    }
+
+    fn is_cache_miss(&self) -> bool {
+        match self {
+            Self::AssetMetadata { .. } => true,
+            Self::Io { source, .. } => source.kind() == io::ErrorKind::NotFound,
+            Self::Serialize { .. } | Self::ModifiedTime { .. } => false,
+        }
+    }
+}
 
 #[derive(Debug, Deserialize, PartialEq, Eq, Serialize)]
 struct VerificationReceipt {
@@ -26,47 +72,90 @@ struct VerifiedAsset {
     modified_nanoseconds: u32,
 }
 
-pub(super) fn receipt_matches(snapshot_dir: &Path, revision: &str, assets: &[ModelAsset]) -> bool {
-    let stored = fs::read(receipt_path(snapshot_dir))
-        .ok()
-        .and_then(|data| serde_json::from_slice::<VerificationReceipt>(&data).ok());
-    let current = capture_receipt(snapshot_dir, revision, assets).ok();
-    stored.is_some() && stored == current
+pub(super) fn receipt_matches(
+    snapshot_dir: &Path,
+    revision: &str,
+    assets: &[ModelAsset],
+) -> Result<bool, VerificationError> {
+    let path = receipt_path(snapshot_dir);
+    let data = match fs::read(&path) {
+        Ok(data) => data,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => {
+            return Err(VerificationError::io(
+                "read verification receipt",
+                &path,
+                error,
+            ))
+        }
+    };
+    let stored = match serde_json::from_slice::<VerificationReceipt>(&data) {
+        Ok(receipt) => receipt,
+        Err(_) => return Ok(false),
+    };
+    match capture_receipt(snapshot_dir, revision, assets) {
+        Ok(current) => Ok(stored == current),
+        Err(error) if error.is_cache_miss() => Ok(false),
+        Err(error) => Err(error),
+    }
 }
 
 pub(super) fn write_receipt(
     snapshot_dir: &Path,
     revision: &str,
     assets: &[ModelAsset],
-) -> io::Result<()> {
+) -> Result<(), VerificationError> {
     let receipt = capture_receipt(snapshot_dir, revision, assets)?;
-    let data = serde_json::to_vec(&receipt).map_err(io::Error::other)?;
     let destination = receipt_path(snapshot_dir);
     let temporary = temporary_receipt_path(snapshot_dir);
+    let data = serde_json::to_vec(&receipt).map_err(|source| VerificationError::Serialize {
+        path: destination.clone(),
+        source,
+    })?;
 
     let mut file = OpenOptions::new()
         .create(true)
         .truncate(true)
         .write(true)
-        .open(&temporary)?;
-    file.write_all(&data)?;
-    file.sync_all()?;
+        .open(&temporary)
+        .map_err(|error| {
+            VerificationError::io("open temporary verification receipt", &temporary, error)
+        })?;
+    file.write_all(&data).map_err(|error| {
+        VerificationError::io("write temporary verification receipt", &temporary, error)
+    })?;
+    file.sync_all().map_err(|error| {
+        VerificationError::io("sync temporary verification receipt", &temporary, error)
+    })?;
 
     if let Err(error) = fs::rename(&temporary, &destination) {
         if error.kind() != io::ErrorKind::AlreadyExists {
-            return Err(error);
+            return Err(VerificationError::io(
+                "install verification receipt",
+                &destination,
+                error,
+            ));
         }
-        fs::remove_file(&destination)?;
-        fs::rename(&temporary, &destination)?;
+        fs::remove_file(&destination).map_err(|error| {
+            VerificationError::io("replace verification receipt", &destination, error)
+        })?;
+        fs::rename(&temporary, &destination).map_err(|error| {
+            VerificationError::io("install verification receipt", &destination, error)
+        })?;
     }
     Ok(())
 }
 
-pub(super) fn remove_receipt(snapshot_dir: &Path) -> io::Result<()> {
-    match fs::remove_file(receipt_path(snapshot_dir)) {
+pub(super) fn remove_receipt(snapshot_dir: &Path) -> Result<(), VerificationError> {
+    let path = receipt_path(snapshot_dir);
+    match fs::remove_file(&path) {
         Ok(()) => Ok(()),
         Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
-        Err(error) => Err(error),
+        Err(error) => Err(VerificationError::io(
+            "remove verification receipt",
+            &path,
+            error,
+        )),
     }
 }
 
@@ -74,11 +163,11 @@ fn capture_receipt(
     snapshot_dir: &Path,
     revision: &str,
     assets: &[ModelAsset],
-) -> io::Result<VerificationReceipt> {
+) -> Result<VerificationReceipt, VerificationError> {
     let assets = assets
         .iter()
         .map(|asset| capture_asset(snapshot_dir, *asset))
-        .collect::<io::Result<Vec<_>>>()?;
+        .collect::<Result<Vec<_>, _>>()?;
     Ok(VerificationReceipt {
         schema_version: RECEIPT_SCHEMA_VERSION,
         revision: revision.to_string(),
@@ -86,18 +175,27 @@ fn capture_receipt(
     })
 }
 
-fn capture_asset(snapshot_dir: &Path, asset: ModelAsset) -> io::Result<VerifiedAsset> {
-    let metadata = fs::metadata(snapshot_dir.join(asset.name))?;
+fn capture_asset(
+    snapshot_dir: &Path,
+    asset: ModelAsset,
+) -> Result<VerifiedAsset, VerificationError> {
+    let path = snapshot_dir.join(asset.name);
+    let metadata = fs::metadata(&path)
+        .map_err(|error| VerificationError::io("read model asset metadata", &path, error))?;
     if !metadata.is_file() || metadata.len() != asset.size {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidData,
-            format!("model asset metadata does not match: {}", asset.name),
-        ));
+        return Err(VerificationError::AssetMetadata {
+            path,
+            expected_size: asset.size,
+        });
     }
     let modified = metadata
-        .modified()?
+        .modified()
+        .map_err(|error| VerificationError::io("read model asset modification time", &path, error))?
         .duration_since(UNIX_EPOCH)
-        .map_err(io::Error::other)?;
+        .map_err(|source| VerificationError::ModifiedTime {
+            path: path.clone(),
+            source,
+        })?;
     Ok(VerifiedAsset {
         name: asset.name.to_string(),
         size: asset.size,
@@ -120,9 +218,9 @@ pub fn receipt_matches_for_tests(
     snapshot_dir: &Path,
     revision: &str,
     assets: &[(&'static str, u64, &'static str)],
-) -> bool {
+) -> Result<bool, String> {
     let assets = test_assets(assets);
-    receipt_matches(snapshot_dir, revision, &assets)
+    receipt_matches(snapshot_dir, revision, &assets).map_err(|error| error.to_string())
 }
 
 #[doc(hidden)]
@@ -130,9 +228,9 @@ pub fn write_receipt_for_tests(
     snapshot_dir: &Path,
     revision: &str,
     assets: &[(&'static str, u64, &'static str)],
-) -> io::Result<()> {
+) -> Result<(), String> {
     let assets = test_assets(assets);
-    write_receipt(snapshot_dir, revision, &assets)
+    write_receipt(snapshot_dir, revision, &assets).map_err(|error| error.to_string())
 }
 
 fn test_assets(assets: &[(&'static str, u64, &'static str)]) -> Vec<ModelAsset> {

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,6 +1,5 @@
 use tauri::{AppHandle, Emitter, State};
 
-use crate::activity::{self, ActivityError, ActivityGuard, AppActivity};
 #[cfg(desktop)]
 use crate::desktop;
 use crate::engine::{EngineState, SpeechEngine};
@@ -16,22 +15,6 @@ fn command_error(context: &str, err: impl UserFacing + std::fmt::Display) -> Str
     user_error(err)
 }
 
-fn reserve_settings_change() -> Result<ActivityGuard, String> {
-    match activity::try_begin(AppActivity::Configuring) {
-        Ok(guard) => Ok(guard),
-        Err(ActivityError::Busy(AppActivity::Recording)) => {
-            Err("Finish the current recording before changing settings.".to_string())
-        }
-        Err(ActivityError::Busy(AppActivity::Updating)) => {
-            Err("Wait for the app update to finish before changing settings.".to_string())
-        }
-        Err(ActivityError::Busy(AppActivity::Configuring)) => {
-            Err("A settings change is already in progress.".to_string())
-        }
-        Err(ActivityError::LockFailed) => Err("Settings are temporarily unavailable.".to_string()),
-    }
-}
-
 async fn run_blocking<T, F>(task: &'static str, work: F) -> Result<T, String>
 where
     T: Send + 'static,
@@ -39,7 +22,10 @@ where
 {
     tauri::async_runtime::spawn_blocking(work)
         .await
-        .map_err(|err| format!("{task} task failed: {err}"))?
+        .map_err(|error| {
+            log::error!("{task} worker failed: {error}");
+            format!("{task} could not complete. Please try again.")
+        })?
 }
 
 #[tauri::command]
@@ -61,9 +47,8 @@ pub fn set_model_path(app: AppHandle, path: String) -> Result<(), String> {
         return Err("Path does not exist or is not a directory".to_string());
     }
 
-    let mut settings = crate::settings::get_settings(&app);
-    settings.model_path = Some(path);
-    crate::settings::save_settings(&app, &settings)
+    crate::settings::set_model_path(&app, path)
+        .map_err(|error| command_error("Could not set model path", error))
 }
 
 #[tauri::command]
@@ -73,9 +58,8 @@ pub fn get_use_streaming(app: AppHandle) -> bool {
 
 #[tauri::command]
 pub fn set_use_streaming(app: AppHandle, enabled: bool) -> Result<(), String> {
-    let mut settings = crate::settings::get_settings(&app);
-    settings.streaming_enabled = enabled;
-    crate::settings::save_settings(&app, &settings)
+    crate::settings::set_streaming_enabled(&app, enabled)
+        .map_err(|error| command_error("Could not set streaming preference", error))
 }
 
 #[tauri::command]
@@ -98,37 +82,10 @@ pub async fn set_asr_language(
 ) -> Result<(), String> {
     let engine = state.inner().clone();
     run_blocking("Speech language", move || {
-        set_asr_language_blocking(app, engine, language)
+        crate::settings::set_asr_language(&app, &engine, language)
+            .map_err(|error| command_error("Could not change speech language", error))
     })
     .await
-}
-
-fn set_asr_language_blocking(
-    app: AppHandle,
-    engine: SpeechEngine,
-    language: String,
-) -> Result<(), String> {
-    let _activity = reserve_settings_change()?;
-    engine
-        .validate_language(&language)
-        .map_err(|error| command_error("Invalid speech language", error))?;
-
-    let mut settings = crate::settings::get_settings(&app);
-    let previous = settings.asr_language.clone();
-    settings.asr_language = language.clone();
-    crate::settings::save_settings(&app, &settings).map_err(|error| {
-        log::error!("Could not persist speech language: {error}");
-        "Could not save the speech language.".to_string()
-    })?;
-
-    if let Err(error) = engine.set_language(&language) {
-        settings.asr_language = previous;
-        if let Err(rollback_error) = crate::settings::save_settings(&app, &settings) {
-            log::error!("Could not roll back speech language setting: {rollback_error}");
-        }
-        return Err(command_error("Could not apply speech language", error));
-    }
-    Ok(())
 }
 
 #[tauri::command]
@@ -212,65 +169,10 @@ pub fn default_record_shortcut() -> String {
 pub async fn reset_settings(app: AppHandle, state: State<'_, SpeechEngine>) -> Result<(), String> {
     let engine = state.inner().clone();
     run_blocking("Settings reset", move || {
-        reset_settings_blocking(app, engine)
+        crate::settings::reset_settings(&app, &engine)
+            .map_err(|error| command_error("Could not reset settings", error))
     })
     .await
-}
-
-fn reset_settings_blocking(app: AppHandle, engine: SpeechEngine) -> Result<(), String> {
-    use crate::settings::{save_settings, Settings};
-
-    let _activity = reserve_settings_change()?;
-    if engine.state() == EngineState::Loading {
-        return Err(
-            "Wait for the speech model to finish loading before resetting settings.".into(),
-        );
-    }
-
-    let previous = crate::settings::get_settings(&app);
-    let settings = Settings::default();
-    if engine.is_ready() {
-        engine
-            .validate_language(&settings.asr_language)
-            .map_err(|error| command_error("Invalid default speech language", error))?;
-    }
-
-    #[cfg(desktop)]
-    let previous_shortcut = desktop::get_record_shortcut(app.clone());
-    #[cfg(desktop)]
-    desktop::update_record_shortcut(app.clone(), desktop::default_record_shortcut()).map_err(
-        |error| {
-            log::error!("Could not reset record shortcut: {error}");
-            "Could not reset the record shortcut.".to_string()
-        },
-    )?;
-
-    if let Err(error) = save_settings(&app, &settings) {
-        #[cfg(desktop)]
-        rollback_shortcut(&app, previous_shortcut.as_deref());
-        return Err(error);
-    }
-    if engine.is_ready() {
-        if let Err(error) = engine.set_language(&settings.asr_language) {
-            if let Err(rollback_error) = save_settings(&app, &previous) {
-                log::error!("Could not roll back settings reset: {rollback_error}");
-            }
-            #[cfg(desktop)]
-            rollback_shortcut(&app, previous_shortcut.as_deref());
-            return Err(command_error("Could not reset speech language", error));
-        }
-    }
-
-    Ok(())
-}
-
-#[cfg(desktop)]
-fn rollback_shortcut(app: &AppHandle, previous: Option<&str>) {
-    if let Some(previous) = previous {
-        if let Err(error) = desktop::update_record_shortcut(app.clone(), previous.to_string()) {
-            log::error!("Could not roll back record shortcut: {error}");
-        }
-    }
 }
 
 #[tauri::command]

--- a/src-tauri/src/desktop/typing.rs
+++ b/src-tauri/src/desktop/typing.rs
@@ -58,7 +58,8 @@ fn typing_sender() -> Result<&'static mpsc::Sender<TypingRequest>, TypingError> 
 }
 
 /// The receiver owns `Enigo` for its entire lifetime. Every request carries an
-/// acknowledgement, so transcript state advances only after typing succeeds.
+/// acknowledgement, so transcript state advances only after the keyboard API
+/// reports success.
 fn typing_worker(receiver: mpsc::Receiver<TypingRequest>) {
     let mut keyboard = Enigo::new(&Settings::default()).map_err(|error| error.to_string());
     while let Ok(request) = receiver.recv() {
@@ -130,8 +131,7 @@ pub(super) fn reset_buffer() -> Result<(), TypingError> {
 }
 
 /// Advances the transcript buffer to `target` only after the submitter
-/// acknowledges the keystrokes, so typed text is never ahead of or behind
-/// the recorded state.
+/// acknowledges the keyboard operation.
 fn deliver<E>(
     current: &mut String,
     target: String,

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -3,9 +3,19 @@ use std::path::PathBuf;
 use tauri::AppHandle;
 use tauri_plugin_store::StoreExt;
 
+mod service;
+mod transaction;
+
+pub(crate) use service::{reset_settings, set_asr_language, set_model_path, set_streaming_enabled};
+#[doc(hidden)]
+pub use transaction::{
+    reset_settings_transaction, set_asr_language_transaction, EngineReadiness, SettingsAction,
+    SettingsTransactionBackend, TransactionFailure,
+};
+
 pub const DEFAULT_ASR_LANGUAGE: &str = "en-US";
 
-#[derive(Serialize, Deserialize)]
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct Settings {
     pub model_path: Option<String>,
     pub streaming_enabled: bool,
@@ -13,6 +23,14 @@ pub struct Settings {
 }
 
 const STORE_PATH: &str = "settings.json";
+
+#[derive(thiserror::Error, Debug)]
+pub enum SettingsStoreError {
+    #[error("open settings store: {0}")]
+    Open(#[source] tauri_plugin_store::Error),
+    #[error("save settings store: {0}")]
+    Save(#[source] tauri_plugin_store::Error),
+}
 
 impl Default for Settings {
     fn default() -> Self {
@@ -51,10 +69,8 @@ pub fn get_settings(app: &AppHandle) -> Settings {
     }
 }
 
-pub fn save_settings(app: &AppHandle, settings: &Settings) -> Result<(), String> {
-    let store = app
-        .store(STORE_PATH)
-        .map_err(|e| format!("Failed to open settings store: {e}"))?;
+pub fn save_settings(app: &AppHandle, settings: &Settings) -> Result<(), SettingsStoreError> {
+    let store = app.store(STORE_PATH).map_err(SettingsStoreError::Open)?;
 
     if let Some(path) = &settings.model_path {
         store.set("model_path", serde_json::json!(path));
@@ -73,7 +89,7 @@ pub fn save_settings(app: &AppHandle, settings: &Settings) -> Result<(), String>
         settings.streaming_enabled
     );
 
-    store.save().map_err(|e| e.to_string())
+    store.save().map_err(SettingsStoreError::Save)
 }
 
 pub fn get_custom_model_path(app: &AppHandle) -> Option<PathBuf> {

--- a/src-tauri/src/settings/service.rs
+++ b/src-tauri/src/settings/service.rs
@@ -1,0 +1,225 @@
+use tauri::AppHandle;
+
+use crate::activity::{self, ActivityError, ActivityGuard, AppActivity};
+#[cfg(desktop)]
+use crate::desktop;
+use crate::engine::{EngineError, EngineState, SpeechEngine};
+use crate::errors::UserFacing;
+
+use super::transaction::{
+    self, EngineReadiness, SettingsAction, SettingsTransactionBackend, TransactionFailure,
+};
+use super::{get_settings, save_settings, Settings, SettingsStoreError};
+
+#[derive(thiserror::Error, Debug)]
+pub(crate) enum SettingsServiceError {
+    #[error(transparent)]
+    Activity(#[from] ActivityError),
+    #[error("{action}: {source}")]
+    Storage {
+        action: SettingsAction,
+        #[source]
+        source: SettingsStoreError,
+    },
+    #[error("{action}: {source}")]
+    Engine {
+        action: SettingsAction,
+        #[source]
+        source: EngineError,
+    },
+    #[cfg(desktop)]
+    #[error("{action}: {detail}")]
+    Shortcut {
+        action: SettingsAction,
+        detail: String,
+    },
+    #[error("speech model is still loading")]
+    ModelLoading,
+    #[error("{action}; original error: {primary}; rollback error: {rollback}")]
+    Rollback {
+        action: SettingsAction,
+        #[source]
+        primary: Box<SettingsServiceError>,
+        rollback: Box<SettingsServiceError>,
+    },
+}
+
+impl UserFacing for SettingsServiceError {
+    fn user_message(&self) -> &'static str {
+        match self {
+            Self::Activity(ActivityError::Busy(AppActivity::Recording)) => {
+                "Finish the current recording before changing settings."
+            }
+            Self::Activity(ActivityError::Busy(AppActivity::Updating)) => {
+                "Wait for the app update to finish before changing settings."
+            }
+            Self::Activity(ActivityError::Busy(AppActivity::Configuring)) => {
+                "A settings change is already in progress."
+            }
+            Self::Activity(ActivityError::LockFailed) => "Settings are temporarily unavailable.",
+            Self::Storage { .. } => "Could not save settings. Please try again.",
+            Self::Engine { source, .. } => source.user_message(),
+            #[cfg(desktop)]
+            Self::Shortcut { .. } => "Could not update the record shortcut.",
+            Self::ModelLoading => {
+                "Wait for the speech model to finish loading before resetting settings."
+            }
+            Self::Rollback { .. } => {
+                "Could not apply settings safely. Please restart the app and try again."
+            }
+        }
+    }
+}
+
+pub(crate) fn set_model_path(app: &AppHandle, path: String) -> Result<(), SettingsServiceError> {
+    let mut settings = get_settings(app);
+    settings.model_path = Some(path);
+    persist(app, &settings, SettingsAction::PersistModelPath)
+}
+
+pub(crate) fn set_streaming_enabled(
+    app: &AppHandle,
+    enabled: bool,
+) -> Result<(), SettingsServiceError> {
+    let mut settings = get_settings(app);
+    settings.streaming_enabled = enabled;
+    persist(app, &settings, SettingsAction::PersistStreamingPreference)
+}
+
+pub(crate) fn set_asr_language(
+    app: &AppHandle,
+    engine: &SpeechEngine,
+    language: String,
+) -> Result<(), SettingsServiceError> {
+    let _activity = reserve_change()?;
+    let mut backend = AppSettingsBackend { app, engine };
+    transaction::set_asr_language_transaction(&mut backend, &language)
+        .map_err(|failure| transaction_error(SettingsAction::SpeechLanguageUpdate, failure))
+}
+
+pub(crate) fn reset_settings(
+    app: &AppHandle,
+    engine: &SpeechEngine,
+) -> Result<(), SettingsServiceError> {
+    let _activity = reserve_change()?;
+    let mut backend = AppSettingsBackend { app, engine };
+    transaction::reset_settings_transaction(&mut backend)
+        .map_err(|failure| transaction_error(SettingsAction::SettingsReset, failure))
+}
+
+struct AppSettingsBackend<'a> {
+    app: &'a AppHandle,
+    engine: &'a SpeechEngine,
+}
+
+impl SettingsTransactionBackend for AppSettingsBackend<'_> {
+    type Error = SettingsServiceError;
+
+    fn current_settings(&self) -> Settings {
+        get_settings(self.app)
+    }
+
+    fn persist_settings(
+        &mut self,
+        settings: &Settings,
+        action: SettingsAction,
+    ) -> Result<(), Self::Error> {
+        persist(self.app, settings, action)
+    }
+
+    fn engine_readiness(&self) -> EngineReadiness {
+        match self.engine.state() {
+            EngineState::Loading => EngineReadiness::Loading,
+            EngineState::Loaded => EngineReadiness::Ready,
+            EngineState::Unloaded | EngineState::Failed(_) => EngineReadiness::Unavailable,
+        }
+    }
+
+    fn validate_language(
+        &mut self,
+        language: &str,
+        action: SettingsAction,
+    ) -> Result<(), Self::Error> {
+        self.engine
+            .validate_language(language)
+            .map_err(|source| SettingsServiceError::Engine { action, source })
+    }
+
+    fn apply_language(
+        &mut self,
+        language: &str,
+        action: SettingsAction,
+    ) -> Result<(), Self::Error> {
+        self.engine
+            .set_language(language)
+            .map(|_| ())
+            .map_err(|source| SettingsServiceError::Engine { action, source })
+    }
+
+    fn current_shortcut(&self) -> Option<String> {
+        #[cfg(desktop)]
+        {
+            desktop::get_record_shortcut(self.app.clone())
+        }
+        #[cfg(not(desktop))]
+        {
+            None
+        }
+    }
+
+    fn default_shortcut(&self) -> Option<String> {
+        #[cfg(desktop)]
+        {
+            Some(desktop::default_record_shortcut())
+        }
+        #[cfg(not(desktop))]
+        {
+            None
+        }
+    }
+
+    fn update_shortcut(
+        &mut self,
+        shortcut: &str,
+        action: SettingsAction,
+    ) -> Result<(), Self::Error> {
+        #[cfg(desktop)]
+        {
+            desktop::update_record_shortcut(self.app.clone(), shortcut.to_string())
+                .map(|_| ())
+                .map_err(|detail| SettingsServiceError::Shortcut { action, detail })
+        }
+        #[cfg(not(desktop))]
+        {
+            let _ = (shortcut, action);
+            Ok(())
+        }
+    }
+}
+
+fn reserve_change() -> Result<ActivityGuard, SettingsServiceError> {
+    activity::try_begin(AppActivity::Configuring).map_err(Into::into)
+}
+
+fn persist(
+    app: &AppHandle,
+    settings: &Settings,
+    action: SettingsAction,
+) -> Result<(), SettingsServiceError> {
+    save_settings(app, settings).map_err(|source| SettingsServiceError::Storage { action, source })
+}
+
+fn transaction_error(
+    action: SettingsAction,
+    failure: TransactionFailure<SettingsServiceError>,
+) -> SettingsServiceError {
+    match failure {
+        TransactionFailure::Operation(error) => error,
+        TransactionFailure::ModelLoading => SettingsServiceError::ModelLoading,
+        TransactionFailure::Rollback { primary, rollback } => SettingsServiceError::Rollback {
+            action,
+            primary: Box::new(transaction_error(action, *primary)),
+            rollback: Box::new(transaction_error(action, *rollback)),
+        },
+    }
+}

--- a/src-tauri/src/settings/transaction.rs
+++ b/src-tauri/src/settings/transaction.rs
@@ -1,0 +1,195 @@
+use std::fmt;
+
+use super::Settings;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum EngineReadiness {
+    Loading,
+    Ready,
+    Unavailable,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SettingsAction {
+    PersistModelPath,
+    PersistStreamingPreference,
+    ValidateSpeechLanguage,
+    PersistSpeechLanguage,
+    ApplySpeechLanguage,
+    RestoreSpeechLanguage,
+    ValidateDefaultSpeechLanguage,
+    ResetRecordShortcut,
+    PersistDefaultSettings,
+    ApplyDefaultSpeechLanguage,
+    RestoreSettings,
+    RestoreRecordShortcut,
+    SpeechLanguageUpdate,
+    SettingsReset,
+}
+
+impl fmt::Display for SettingsAction {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let description = match self {
+            Self::PersistModelPath => "persist model path",
+            Self::PersistStreamingPreference => "persist streaming preference",
+            Self::ValidateSpeechLanguage => "validate speech language",
+            Self::PersistSpeechLanguage => "persist speech language",
+            Self::ApplySpeechLanguage => "apply speech language",
+            Self::RestoreSpeechLanguage => "restore speech language",
+            Self::ValidateDefaultSpeechLanguage => "validate default speech language",
+            Self::ResetRecordShortcut => "reset record shortcut",
+            Self::PersistDefaultSettings => "persist default settings",
+            Self::ApplyDefaultSpeechLanguage => "apply default speech language",
+            Self::RestoreSettings => "restore settings",
+            Self::RestoreRecordShortcut => "restore record shortcut",
+            Self::SpeechLanguageUpdate => "speech language update",
+            Self::SettingsReset => "settings reset",
+        };
+        formatter.write_str(description)
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub enum TransactionFailure<E> {
+    Operation(E),
+    ModelLoading,
+    Rollback {
+        primary: Box<TransactionFailure<E>>,
+        rollback: Box<TransactionFailure<E>>,
+    },
+}
+
+pub trait SettingsTransactionBackend {
+    type Error;
+
+    fn current_settings(&self) -> Settings;
+    fn persist_settings(
+        &mut self,
+        settings: &Settings,
+        action: SettingsAction,
+    ) -> Result<(), Self::Error>;
+    fn engine_readiness(&self) -> EngineReadiness;
+    fn validate_language(
+        &mut self,
+        language: &str,
+        action: SettingsAction,
+    ) -> Result<(), Self::Error>;
+    fn apply_language(&mut self, language: &str, action: SettingsAction)
+        -> Result<(), Self::Error>;
+    fn current_shortcut(&self) -> Option<String>;
+    fn default_shortcut(&self) -> Option<String>;
+    fn update_shortcut(
+        &mut self,
+        shortcut: &str,
+        action: SettingsAction,
+    ) -> Result<(), Self::Error>;
+}
+
+pub fn set_asr_language_transaction<B: SettingsTransactionBackend>(
+    backend: &mut B,
+    language: &str,
+) -> Result<(), TransactionFailure<B::Error>> {
+    operation(backend.validate_language(language, SettingsAction::ValidateSpeechLanguage))?;
+
+    let mut settings = backend.current_settings();
+    let previous = settings.asr_language.clone();
+    settings.asr_language = language.to_string();
+    operation(backend.persist_settings(&settings, SettingsAction::PersistSpeechLanguage))?;
+
+    let apply = operation(backend.apply_language(language, SettingsAction::ApplySpeechLanguage));
+    rollback_on_failure(apply, || {
+        settings.asr_language = previous;
+        operation(backend.persist_settings(&settings, SettingsAction::RestoreSpeechLanguage))
+    })
+}
+
+pub fn reset_settings_transaction<B: SettingsTransactionBackend>(
+    backend: &mut B,
+) -> Result<(), TransactionFailure<B::Error>> {
+    let readiness = backend.engine_readiness();
+    if readiness == EngineReadiness::Loading {
+        return Err(TransactionFailure::ModelLoading);
+    }
+
+    let previous_settings = backend.current_settings();
+    let defaults = Settings::default();
+    if readiness == EngineReadiness::Ready {
+        operation(backend.validate_language(
+            &defaults.asr_language,
+            SettingsAction::ValidateDefaultSpeechLanguage,
+        ))?;
+    }
+
+    let previous_shortcut = backend.current_shortcut();
+    if let Some(default_shortcut) = backend.default_shortcut() {
+        operation(backend.update_shortcut(&default_shortcut, SettingsAction::ResetRecordShortcut))?;
+    }
+
+    let persist =
+        operation(backend.persist_settings(&defaults, SettingsAction::PersistDefaultSettings));
+    rollback_on_failure(persist, || {
+        restore_shortcut(backend, previous_shortcut.as_deref())
+    })?;
+
+    if readiness != EngineReadiness::Ready {
+        return Ok(());
+    }
+
+    let apply = operation(backend.apply_language(
+        &defaults.asr_language,
+        SettingsAction::ApplyDefaultSpeechLanguage,
+    ));
+    rollback_on_failure(apply, || {
+        let settings = operation(
+            backend.persist_settings(&previous_settings, SettingsAction::RestoreSettings),
+        );
+        let shortcut = restore_shortcut(backend, previous_shortcut.as_deref());
+        combine_rollbacks(settings, shortcut)
+    })
+}
+
+fn restore_shortcut<B: SettingsTransactionBackend>(
+    backend: &mut B,
+    previous: Option<&str>,
+) -> Result<(), TransactionFailure<B::Error>> {
+    match previous {
+        Some(shortcut) => {
+            operation(backend.update_shortcut(shortcut, SettingsAction::RestoreRecordShortcut))
+        }
+        None => Ok(()),
+    }
+}
+
+fn operation<E>(result: Result<(), E>) -> Result<(), TransactionFailure<E>> {
+    result.map_err(TransactionFailure::Operation)
+}
+
+fn rollback_on_failure<E>(
+    result: Result<(), TransactionFailure<E>>,
+    rollback: impl FnOnce() -> Result<(), TransactionFailure<E>>,
+) -> Result<(), TransactionFailure<E>> {
+    match result {
+        Ok(()) => Ok(()),
+        Err(primary) => match rollback() {
+            Ok(()) => Err(primary),
+            Err(rollback) => Err(TransactionFailure::Rollback {
+                primary: Box::new(primary),
+                rollback: Box::new(rollback),
+            }),
+        },
+    }
+}
+
+fn combine_rollbacks<E>(
+    first: Result<(), TransactionFailure<E>>,
+    second: Result<(), TransactionFailure<E>>,
+) -> Result<(), TransactionFailure<E>> {
+    match (first, second) {
+        (Ok(()), Ok(())) => Ok(()),
+        (Err(error), Ok(())) | (Ok(()), Err(error)) => Err(error),
+        (Err(primary), Err(rollback)) => Err(TransactionFailure::Rollback {
+            primary: Box::new(primary),
+            rollback: Box::new(rollback),
+        }),
+    }
+}

--- a/src-tauri/tests/model_store_tests.rs
+++ b/src-tauri/tests/model_store_tests.rs
@@ -78,30 +78,28 @@ fn verification_receipt_tracks_snapshot_metadata_and_manifest() {
     std::fs::write(snapshot.join("asset.bin"), b"model").expect("fixture should be writable");
 
     let assets = [("asset.bin", 5, "expected-sha256")];
-    assert!(!verification_receipt_matches_for_tests(
-        &snapshot,
-        "revision-a",
-        &assets,
-    ));
+    assert!(
+        !verification_receipt_matches_for_tests(&snapshot, "revision-a", &assets)
+            .expect("receipt inspection should succeed")
+    );
 
     write_verification_receipt_for_tests(&snapshot, "revision-a", &assets)
         .expect("verification receipt should be writable");
-    assert!(verification_receipt_matches_for_tests(
-        &snapshot,
-        "revision-a",
-        &assets,
-    ));
+    assert!(
+        verification_receipt_matches_for_tests(&snapshot, "revision-a", &assets)
+            .expect("receipt inspection should succeed")
+    );
 
-    assert!(!verification_receipt_matches_for_tests(
-        &snapshot,
-        "revision-b",
-        &assets,
-    ));
+    assert!(
+        !verification_receipt_matches_for_tests(&snapshot, "revision-b", &assets)
+            .expect("receipt inspection should succeed")
+    );
     assert!(!verification_receipt_matches_for_tests(
         &snapshot,
         "revision-a",
         &[("asset.bin", 5, "replacement-sha256")],
-    ));
+    )
+    .expect("receipt inspection should succeed"));
 
     let asset_path = snapshot.join("asset.bin");
     std::fs::write(&asset_path, b"other").expect("fixture should be replaceable");
@@ -115,11 +113,16 @@ fn verification_receipt_tracks_snapshot_metadata_and_manifest() {
             .len(),
         5,
     );
-    assert!(!verification_receipt_matches_for_tests(
-        &snapshot,
-        "revision-a",
-        &assets,
-    ));
+    assert!(
+        !verification_receipt_matches_for_tests(&snapshot, "revision-a", &assets)
+            .expect("receipt inspection should succeed")
+    );
+
+    let missing_snapshot = temp_dir.join("missing");
+    let error = write_verification_receipt_for_tests(&missing_snapshot, "revision-a", &assets)
+        .expect_err("missing asset metadata should be contextualized");
+    assert!(error.contains("read model asset metadata"));
+    assert!(error.contains("asset.bin"));
 
     let _ = std::fs::remove_dir_all(temp_dir);
 }

--- a/src-tauri/tests/settings_transaction_tests.rs
+++ b/src-tauri/tests/settings_transaction_tests.rs
@@ -1,0 +1,213 @@
+use silent_keys_lib::settings::{
+    reset_settings_transaction, set_asr_language_transaction, EngineReadiness, Settings,
+    SettingsAction, SettingsTransactionBackend, TransactionFailure,
+};
+
+struct FakeSettingsBackend {
+    settings: Settings,
+    readiness: EngineReadiness,
+    shortcut: Option<String>,
+    failures: Vec<(SettingsAction, &'static str)>,
+    calls: Vec<SettingsAction>,
+}
+
+impl FakeSettingsBackend {
+    fn new() -> Self {
+        Self {
+            settings: Settings {
+                model_path: Some("/models/custom".to_string()),
+                streaming_enabled: true,
+                asr_language: "en-US".to_string(),
+            },
+            readiness: EngineReadiness::Ready,
+            shortcut: Some("Alt+X".to_string()),
+            failures: Vec::new(),
+            calls: Vec::new(),
+        }
+    }
+
+    fn fail(&mut self, action: SettingsAction, message: &'static str) {
+        self.failures.push((action, message));
+    }
+
+    fn operation(&mut self, action: SettingsAction) -> Result<(), &'static str> {
+        self.calls.push(action);
+        self.failures
+            .iter()
+            .find_map(|(candidate, message)| (*candidate == action).then_some(*message))
+            .map_or(Ok(()), Err)
+    }
+}
+
+impl SettingsTransactionBackend for FakeSettingsBackend {
+    type Error = &'static str;
+
+    fn current_settings(&self) -> Settings {
+        self.settings.clone()
+    }
+
+    fn persist_settings(
+        &mut self,
+        settings: &Settings,
+        action: SettingsAction,
+    ) -> Result<(), Self::Error> {
+        self.operation(action)?;
+        self.settings = settings.clone();
+        Ok(())
+    }
+
+    fn engine_readiness(&self) -> EngineReadiness {
+        self.readiness
+    }
+
+    fn validate_language(
+        &mut self,
+        _language: &str,
+        action: SettingsAction,
+    ) -> Result<(), Self::Error> {
+        self.operation(action)
+    }
+
+    fn apply_language(
+        &mut self,
+        _language: &str,
+        action: SettingsAction,
+    ) -> Result<(), Self::Error> {
+        self.operation(action)
+    }
+
+    fn current_shortcut(&self) -> Option<String> {
+        self.shortcut.clone()
+    }
+
+    fn default_shortcut(&self) -> Option<String> {
+        Some("Alt+Z".to_string())
+    }
+
+    fn update_shortcut(
+        &mut self,
+        shortcut: &str,
+        action: SettingsAction,
+    ) -> Result<(), Self::Error> {
+        self.operation(action)?;
+        self.shortcut = Some(shortcut.to_string());
+        Ok(())
+    }
+}
+
+#[test]
+fn language_transaction_persists_and_applies_selection() {
+    let mut backend = FakeSettingsBackend::new();
+
+    set_asr_language_transaction(&mut backend, "fr-FR").expect("transaction should succeed");
+
+    assert_eq!(backend.settings.asr_language, "fr-FR");
+    assert_eq!(
+        backend.calls,
+        [
+            SettingsAction::ValidateSpeechLanguage,
+            SettingsAction::PersistSpeechLanguage,
+            SettingsAction::ApplySpeechLanguage,
+        ]
+    );
+}
+
+#[test]
+fn language_transaction_restores_persisted_selection_after_apply_failure() {
+    let mut backend = FakeSettingsBackend::new();
+    backend.fail(SettingsAction::ApplySpeechLanguage, "apply failed");
+
+    let error = set_asr_language_transaction(&mut backend, "fr-FR")
+        .expect_err("apply failure should be returned");
+
+    assert_eq!(error, TransactionFailure::Operation("apply failed"));
+    assert_eq!(backend.settings.asr_language, "en-US");
+    assert!(backend
+        .calls
+        .contains(&SettingsAction::RestoreSpeechLanguage));
+}
+
+#[test]
+fn language_transaction_preserves_apply_and_rollback_failures() {
+    let mut backend = FakeSettingsBackend::new();
+    backend.fail(SettingsAction::ApplySpeechLanguage, "apply failed");
+    backend.fail(SettingsAction::RestoreSpeechLanguage, "restore failed");
+
+    let error = set_asr_language_transaction(&mut backend, "fr-FR")
+        .expect_err("both failures should be returned");
+
+    assert_eq!(
+        error,
+        TransactionFailure::Rollback {
+            primary: Box::new(TransactionFailure::Operation("apply failed")),
+            rollback: Box::new(TransactionFailure::Operation("restore failed")),
+        }
+    );
+}
+
+#[test]
+fn reset_restores_shortcut_when_settings_persistence_fails() {
+    let mut backend = FakeSettingsBackend::new();
+    let previous_settings = backend.settings.clone();
+    backend.fail(SettingsAction::PersistDefaultSettings, "persist failed");
+
+    let error = reset_settings_transaction(&mut backend)
+        .expect_err("settings persistence failure should be returned");
+
+    assert_eq!(error, TransactionFailure::Operation("persist failed"));
+    assert_eq!(backend.settings, previous_settings);
+    assert_eq!(backend.shortcut.as_deref(), Some("Alt+X"));
+}
+
+#[test]
+fn reset_restores_settings_and_shortcut_when_language_apply_fails() {
+    let mut backend = FakeSettingsBackend::new();
+    let previous_settings = backend.settings.clone();
+    backend.fail(SettingsAction::ApplyDefaultSpeechLanguage, "apply failed");
+
+    let error = reset_settings_transaction(&mut backend)
+        .expect_err("language apply failure should be returned");
+
+    assert_eq!(error, TransactionFailure::Operation("apply failed"));
+    assert_eq!(backend.settings, previous_settings);
+    assert_eq!(backend.shortcut.as_deref(), Some("Alt+X"));
+}
+
+#[test]
+fn reset_preserves_each_rollback_failure() {
+    let mut backend = FakeSettingsBackend::new();
+    backend.fail(SettingsAction::ApplyDefaultSpeechLanguage, "apply failed");
+    backend.fail(SettingsAction::RestoreSettings, "settings restore failed");
+    backend.fail(
+        SettingsAction::RestoreRecordShortcut,
+        "shortcut restore failed",
+    );
+
+    let error = reset_settings_transaction(&mut backend)
+        .expect_err("all rollback failures should be returned");
+
+    assert_eq!(
+        error,
+        TransactionFailure::Rollback {
+            primary: Box::new(TransactionFailure::Operation("apply failed")),
+            rollback: Box::new(TransactionFailure::Rollback {
+                primary: Box::new(TransactionFailure::Operation("settings restore failed")),
+                rollback: Box::new(TransactionFailure::Operation("shortcut restore failed")),
+            }),
+        }
+    );
+}
+
+#[test]
+fn reset_waits_for_loading_model_before_mutating_settings() {
+    let mut backend = FakeSettingsBackend::new();
+    let previous_settings = backend.settings.clone();
+    backend.readiness = EngineReadiness::Loading;
+
+    let error =
+        reset_settings_transaction(&mut backend).expect_err("loading model should block the reset");
+
+    assert_eq!(error, TransactionFailure::ModelLoading);
+    assert_eq!(backend.settings, previous_settings);
+    assert!(backend.calls.is_empty());
+}

--- a/src-tauri/tests/text_delivery_tests.rs
+++ b/src-tauri/tests/text_delivery_tests.rs
@@ -39,7 +39,7 @@ fn text_commits_only_after_typing_is_acknowledged() {
 }
 
 #[test]
-fn buffer_stays_unchanged_when_typing_fails() {
+fn buffer_stays_unchanged_when_submission_reports_failure() {
     let mut buffer = "hello".to_string();
 
     let result = deliver_for_tests(&mut buffer, "goodbye".to_string(), |_| {


### PR DESCRIPTION
## Summary

Follow-up to #8 before publishing 0.3.0.

- preserve structured store, rollback, and model-verification errors with operation/path context
- move settings transactions behind a Tauri-free boundary and cover success, failure, and rollback paths
- document the supported macOS Gatekeeper first-launch flow
- correct the release note so virtual typing promises acknowledgement, not impossible transactional keystrokes

## Validation

- cargo fmt --all -- --check
- cargo test --workspace
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- trunk build --release
- cargo tauri build --debug --no-bundle
- standards review: no hard violations
- spec review: no findings
