### PR TITLE
Fix Linux release runner compatibility

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,7 @@ jobs:
             rust_targets: ''
             label: 'windows-x64'
 
-          - platform: ubuntu-22.04
+          - platform: ubuntu-24.04
             args: ''
             rust_targets: ''
             label: 'linux-x64'
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: install dependencies (ubuntu only)
-        if: matrix.platform == 'ubuntu-22.04'
+        if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ### Changed
 
+- Aligned experimental Linux release builds with ONNX Runtime's glibc 2.39
+  minimum (Ubuntu 24.04 or Debian 13).
 - Updated the Rust dependency graph to the latest compatible releases.
 - Hardened resumable model downloads with temporary files, digest validation,
   atomic installation, and repair of corrupt cached assets.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Audio and transcription stay on-device. No telemetry.
 SilentKeys is a desktop dictation app that performs all audio capture and transcription locally on your machine, streaming text into whatever application has focus — no plugins required. The scope is deliberately narrow: local, system-wide speech-to-text and nothing else. It is designed for everyday use on Apple Silicon Macs and remains under active development.
 
 - **Target Platform**: macOS 14+ on Apple Silicon (M1/M2/M3/M4).
-- **Secondary Platforms**: The release workflow targets Intel macOS, Linux, and Windows, but those builds remain experimental until their platform acceptance gates pass.
+- **Secondary Platforms**: The release workflow targets Intel macOS, Linux, and Windows, but those builds remain experimental until their platform acceptance gates pass. Linux builds require glibc 2.39 or newer (Ubuntu 24.04 or Debian 13).
 - **Resource Footprint** (measured on an M-series Mac):
   - **App executable**: approximately 20 MB; signed updater archive approximately 9 MB
   - **Downloaded model**: approximately 683 MB


### PR DESCRIPTION
## Summary
- build the experimental Linux release on Ubuntu 24.04, matching the pinned ONNX Runtime binary requirement
- keep Linux dependency installation independent of the versioned runner label
- document the glibc 2.39 minimum in the README and 0.3.0 changelog

## Root cause
The pinned ort-sys 2.0.0-rc.12 archive references GLIBC_2.38 symbols. Ubuntu 22.04 provides glibc 2.35, while the upstream prebuilt-binary contract requires glibc 2.39 / Ubuntu 24.04: https://github.com/pykeio/ort/issues/523

## Validation
- reproduced the missing __isoc23_strtol link on Ubuntu 22.04
- confirmed the same probe links on Ubuntu 24.04
- verified workflow YAML and exact runner assertions
- git diff --check
- independent standards review: no findings
- independent spec review: no findings

AGENTS.md and todo.md remain untracked and are not part of this PR.