### PR TITLE
Remove unsupported macOS Intel release target

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,11 +20,6 @@ jobs:
             rust_targets: 'aarch64-apple-darwin'
             label: 'macos-arm64'
 
-          - platform: macos-latest
-            args: '--target x86_64-apple-darwin'
-            rust_targets: 'x86_64-apple-darwin'
-            label: 'macos-intel'
-
           - platform: windows-latest
             args: ''
             rust_targets: ''
@@ -104,7 +99,7 @@ jobs:
           gh release download "app-v${version}" --pattern latest.json --dir updater-manifest
           jq -e --arg version "$version" '
             .version == $version and
-            ((["darwin-aarch64", "darwin-x86_64", "linux-x86_64", "windows-x86_64"]
+            ((["darwin-aarch64", "linux-x86_64", "windows-x86_64"]
               - (.platforms | keys)) | length == 0) and
             ([.platforms[] |
               (.signature | length > 0) and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@
 
 - Aligned experimental Linux release builds with ONNX Runtime's glibc 2.39
   minimum (Ubuntu 24.04 or Debian 13).
+- Removed the unsupported Intel macOS release target; macOS releases require
+  Apple Silicon.
 - Updated the Rust dependency graph to the latest compatible releases.
 - Hardened resumable model downloads with temporary files, digest validation,
   atomic installation, and repair of corrupt cached assets.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Audio and transcription stay on-device. No telemetry.
 SilentKeys is a desktop dictation app that performs all audio capture and transcription locally on your machine, streaming text into whatever application has focus — no plugins required. The scope is deliberately narrow: local, system-wide speech-to-text and nothing else. It is designed for everyday use on Apple Silicon Macs and remains under active development.
 
 - **Target Platform**: macOS 14+ on Apple Silicon (M1/M2/M3/M4).
-- **Secondary Platforms**: The release workflow targets Intel macOS, Linux, and Windows, but those builds remain experimental until their platform acceptance gates pass. Linux builds require glibc 2.39 or newer (Ubuntu 24.04 or Debian 13).
+- **Secondary Platforms**: The release workflow targets Linux and Windows, but those builds remain experimental until their platform acceptance gates pass. Linux builds require glibc 2.39 or newer (Ubuntu 24.04 or Debian 13).
 - **Resource Footprint** (measured on an M-series Mac):
   - **App executable**: approximately 20 MB; signed updater archive approximately 9 MB
   - **Downloaded model**: approximately 683 MB


### PR DESCRIPTION
## Summary
- remove the macOS Intel job that cannot build with the pinned ONNX Runtime backend
- require updater signatures for the three buildable targets: macOS ARM64, Linux x64, and Windows x64
- align README and 0.3.0 changelog with Apple Silicon-only macOS support

## Root cause
Publish run 29547250992 passed tests and strict clippy on the Intel job, then ort-sys rejected x86_64-apple-darwin because no prebuilt runtime exists. Both Pyke ort and Microsoft ONNX Runtime 1.24.2 list only macOS ARM64 support/artifacts.

## Validation
- deterministic workflow assertion rejects all stale Intel target keys
- workflow YAML parses cleanly
- git diff --check
- independent standards review: no blocking findings
- independent spec review: no findings

AGENTS.md and todo.md remain untracked and are not part of this PR.