### PR TITLE
Fix verification receipt test on Windows

### DIFF
--- a/src-tauri/tests/model_store_tests.rs
+++ b/src-tauri/tests/model_store_tests.rs
@@ -103,8 +103,10 @@ fn verification_receipt_tracks_snapshot_metadata_and_manifest() {
 
     let asset_path = snapshot.join("asset.bin");
     std::fs::write(&asset_path, b"other").expect("fixture should be replaceable");
-    std::fs::File::open(&asset_path)
-        .expect("fixture should be readable")
+    std::fs::OpenOptions::new()
+        .write(true)
+        .open(&asset_path)
+        .expect("fixture should be writable")
         .set_modified(UNIX_EPOCH + Duration::from_secs(1))
         .expect("fixture modification time should be adjustable");
     assert_eq!(


### PR DESCRIPTION
## Summary
- open the receipt-test fixture with write access before changing its modification time
- keep the portability fix confined to test code

## Why
Windows requires a writable file handle for SetFileTime; File::open creates a read-only handle and caused the publish workflow test job to fail with Access is denied.

## Validation
- focused verification receipt regression
- cargo fmt --all -- --check
- cargo test --workspace
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- git diff --check

AGENTS.md and todo.md are intentionally excluded.